### PR TITLE
Use correct way of declaring utf-8 encoding in python

### DIFF
--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import sys
 import os


### PR DESCRIPTION
I had trouble in emacs when saving and it turns out a `hyphen` was missing in utf-8