### PR TITLE
Adding systemd support, miscellaneous improvements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@ include dmenu_extended_run
 include dmenu_extended_cache_build
 include dmenu_extended.py
 include systemd-install.sh
-include systemd/update-dmenu-extended-db.service
+include systemd/update-dmenu-extended-db.system.service
+include systemd/update-dmenu-extended-db.user.service
 include systemd/update-dmenu-extended-db.timer

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 include dmenu_extended_run
+include dmenu_extended_cache_build
 include dmenu_extended.py
+include systemd-install.sh
+include systemd/update-dmenu-extended-db.service
+include systemd/update-dmenu-extended-db.timer

--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -106,7 +106,8 @@ default_prefs = {
     "terminal": "xterm",                # Terminal
     "indicator_submenu": "->",          # Symbol to indicate a submenu item
     "indicator_edit": "*",              # Symbol to indicate an item will launch an editor
-    "indicator_alias": ""              # Symbol to indecate an aliased command
+    "indicator_alias": "",              # Symbol to indecate an aliased command
+    "prompt": "Open:"                   # Prompt
 }
 
 def initialize_d(launch_args):
@@ -1287,7 +1288,8 @@ def run(*args):
 
     d.load_preferences()
     cache = d.cache_load()
-    out = d.menu(cache,'Open:').strip()
+    prompt = d.prefs['prompt']
+    out = d.menu(cache,prompt).strip()
 
     if len(out) > 0:
         if d.debug:

--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -109,6 +109,17 @@ default_prefs = {
     "indicator_alias": ""              # Symbol to indecate an aliased command
 }
 
+def initialize_d(launch_args):
+    global d
+    if d is None:
+        d = dmenu()
+        d.launch_args = launch_args
+
+        if '--debug' in d.launch_args:
+            d.debug = True
+            d.launch_args.remove('--debug')
+            print('Debugging enabled')
+            print('Launch arguments: ' + str(launch_args))
 
 def setup_user_files():
     """ Returns nothing
@@ -185,6 +196,10 @@ import plugins
 
 
 def load_plugins(debug=False):
+    global d
+
+    initialize_d([])
+
     if debug:
         print('Loading plugins')
 
@@ -781,7 +796,7 @@ class dmenu(object):
                     parts = line[6:].replace('\n','').replace('\'','').replace('"','').split('=')
                     out.append([parts[0], parts[1]])
         return out
-                    
+
 
     def cache_build(self):
         self.load_preferences()
@@ -1266,18 +1281,9 @@ def handle_command(d, out):
 
 
 def run(*args):
-    global d
-
     launch_args = list(args[1:])
 
-    d = dmenu()
-    d.launch_args = launch_args
-
-    if '--debug' in d.launch_args:
-        d.debug = True
-        d.launch_args.remove('--debug')
-        print('Debugging enabled')
-        print('Launch arguments: ' + str(launch_args))
+    initialize_d(launch_args)
 
     d.load_preferences()
     cache = d.cache_load()
@@ -1390,7 +1396,7 @@ def run(*args):
                                 print("No")
 
                         # If removing a command - an alias would be detected as a command
-                        
+
                         if action == '-' and type(item) == list:
                             if d.debug:
                                 print("Is (-) " + str(d.format_alias(item[0], item[1])) + " == " + str(command) + "?")
@@ -1422,7 +1428,7 @@ def run(*args):
                                     print("Alias is now: " + str(alias))
                                 break
                             elif d.debug:
-                                print("No") 
+                                print("No")
 
                             if d.debug:
                                 print("Is (-) " + str(item[0]) + " == " + str(command) + "?")
@@ -1438,7 +1444,7 @@ def run(*args):
                                     print("Alias is now: " + str(alias))
                                 break
                             elif d.debug:
-                                print("No") 
+                                print("No")
 
                         if type(item) != list:
                             if d.debug:
@@ -1468,7 +1474,7 @@ def run(*args):
                             answer = d.menu("Alias '" + str(alias) + "' was not found in store\n"+option)
                         if answer != option:
                             sys.exit()
-                        action = '+'                    
+                        action = '+'
 
 
                     cache_scanned = d.cache_open(file_cache)[:-1]
@@ -1546,7 +1552,7 @@ def run(*args):
                         sys.exit()
 
                     d.save_preferences()
-                    d.cache_save(cache_scanned, file_cache)                        
+                    d.cache_save(cache_scanned, file_cache)
                     d.message_close()
 
                     # Give the user some feedback

--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -197,8 +197,6 @@ import plugins
 
 
 def load_plugins(debug=False):
-    global d
-
     initialize_d([])
 
     if debug:

--- a/dmenu_extended_cache_build
+++ b/dmenu_extended_cache_build
@@ -1,0 +1,6 @@
+#! /usr/bin/env python
+# -*- coding: utf8 -*-
+import dmenu_extended 
+if __name__ == "__main__":
+    print("Rebuilding dmenu_extended cache...")
+    dmenu_extended.dmenu().cache_build()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from distutils.core import setup
 
 # __version__ = None

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,10 @@ setup(name='dmenu_extended',
       url='https://github.com/markjones112358/dmenu-extended',
       py_modules=['dmenu_extended'],
       # packages=['dmenu_extended', 'dmenu_extended/config', 'dmenu_extended/plugins'],
-      scripts=['dmenu_extended_run']
+      scripts=['dmenu_extended_run', 'dmenu_extended_cache_build'],
+      data_files=[
+          ('/usr/lib/systemd/user', [
+              'systemd/update-dmenu-extended-db.service',
+              'systemd/update-dmenu-extended-db.timer'
+              ])]
       )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='dmenu_extended',
       scripts=['dmenu_extended_run', 'dmenu_extended_cache_build'],
       data_files=[('share/dmenu-extended/', ['systemd-install.sh']),
                   ('share/dmenu-extended/systemd',
-                      ['systemd/update-dmenu-extended-db.service',
+                      ['systemd/update-dmenu-extended-db.system.service',
+                       'systemd/update-dmenu-extended-db.user.service',
                        'systemd/update-dmenu-extended-db.timer'])]
       )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from distutils.core import setup
 
 # __version__ = None
@@ -18,9 +19,8 @@ setup(name='dmenu_extended',
       py_modules=['dmenu_extended'],
       # packages=['dmenu_extended', 'dmenu_extended/config', 'dmenu_extended/plugins'],
       scripts=['dmenu_extended_run', 'dmenu_extended_cache_build'],
-      data_files=[
-          ('/usr/lib/systemd/user', [
-              'systemd/update-dmenu-extended-db.service',
-              'systemd/update-dmenu-extended-db.timer'
-              ])]
+      data_files=[('share/dmenu-extended/', ['systemd-install.sh']),
+                  ('share/dmenu-extended/systemd',
+                      ['systemd/update-dmenu-extended-db.service',
+                       'systemd/update-dmenu-extended-db.timer'])]
       )

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -17,8 +17,10 @@ done
 
 if [ "$PER_USER_INSTALL" == "YES" ] ; then
 	SCRIPT_PATH=$HOME/.local/share/systemd/user
+	SERVICE_UNIT_NAME=update-dmenu-extended-db.user.service
 else
 	SCRIPT_PATH=/usr/lib/systemd/user
+	SERVICE_UNIT_NAME=update-dmenu-extended-db.system.service
 fi
 
 if [ "$UNINSTALL" == "YES" ]; then
@@ -33,4 +35,5 @@ if [ ! -d "$SCRIPT_PATH" ]; then
 fi
 
 echo "Installing systemd service in $SCRIPT_PATH..." 
-cp -v systemd/{update-dmenu-extended-db.service,update-dmenu-extended-db.timer} $SCRIPT_PATH
+cp -v systemd/$SERVICE_UNIT_NAME $SCRIPT_PATH/update-dmenu-extended-db.service
+cp -v systemd/update-dmenu-extended-db.timer $SCRIPT_PATH

--- a/systemd-install.sh
+++ b/systemd-install.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Installs dmenu_extended_cache_build as a systemd service to be executed every 20 minutes
+
+# Process command line arguments
+for i in "$@"
+do
+	case $i in
+		-u|--user)
+			PER_USER_INSTALL=YES
+			shift # past argument=value
+			;;
+		-d|--uninstall)
+			UNINSTALL=YES
+
+	esac
+done
+
+if [ "$PER_USER_INSTALL" == "YES" ] ; then
+	SCRIPT_PATH=$HOME/.local/share/systemd/user
+else
+	SCRIPT_PATH=/usr/lib/systemd/user
+fi
+
+if [ "$UNINSTALL" == "YES" ]; then
+	echo "Uninstalling systemd service in $SCRIPT_PATH..."
+	rm -v $SCRIPT_PATH/{update-dmenu-extended-db.service,update-dmenu-extended-db.timer}
+	exit
+fi
+
+if [ ! -d "$SCRIPT_PATH" ]; then
+	echo "Creating directory $SCRIPT_PATH..."
+	mkdir -p $SCRIPT_PATH
+fi
+
+echo "Installing systemd service in $SCRIPT_PATH..." 
+cp -v systemd/{update-dmenu-extended-db.service,update-dmenu-extended-db.timer} $SCRIPT_PATH

--- a/systemd/update-dmenu-extended-db.service
+++ b/systemd/update-dmenu-extended-db.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Updates the database file used by dmenu_extended_run
+
+[Service]
+Type=oneshot
+User=%i
+ExecStart=/usr/bin/dmenu_extended_cache_build

--- a/systemd/update-dmenu-extended-db.service
+++ b/systemd/update-dmenu-extended-db.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Updates the database file used by dmenu_extended_run
-
-[Service]
-Type=oneshot
-User=%i
-ExecStart=/usr/bin/dmenu_extended_cache_build

--- a/systemd/update-dmenu-extended-db.system.service
+++ b/systemd/update-dmenu-extended-db.system.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Updates the database file used by dmenu_extended_run
+
+[Service]
+Type=oneshot
+User=%i
+ExecStart=/usr/bin/dmenu_extended_cache_build

--- a/systemd/update-dmenu-extended-db.timer
+++ b/systemd/update-dmenu-extended-db.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run update-dmenu-extended-db.service every 5 minutes
+Description=Run update-dmenu-extended-db.service every 20 minutes
 
 [Timer]
 OnCalendar=*:0/20

--- a/systemd/update-dmenu-extended-db.timer
+++ b/systemd/update-dmenu-extended-db.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run update-dmenu-extended-db.service every 5 minutes
+
+[Timer]
+OnCalendar=*:0/20
+
+[Install]
+WantedBy=timers.target

--- a/systemd/update-dmenu-extended-db.user.service
+++ b/systemd/update-dmenu-extended-db.user.service
@@ -4,4 +4,4 @@ Description=Updates the database file used by dmenu_extended_run
 [Service]
 Type=oneshot
 User=%i
-ExecStart=/home/%i/.local/bin/dmenu_extended_cache_build
+ExecStart=/bin/sh -c "~/.local/bin/dmenu_extended_cache_build"

--- a/systemd/update-dmenu-extended-db.user.service
+++ b/systemd/update-dmenu-extended-db.user.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Updates the database file used by dmenu_extended_run
+
+[Service]
+Type=oneshot
+User=%i
+ExecStart=/home/%i/.local/bin/dmenu_extended_cache_build


### PR DESCRIPTION
## Adding systemd support to dmenu_extended

This patch adds specifically a menu option to manage a systemd service to automatically rebuild the cache file every 20 minutes. The menu option is automatically generated depending on whether systemd is available, whether the systemd unit files are installed, and whether they are currently active.

A python script to rebuild the cache file is provided in `dmenu_extended_cache_build`.

Unit files are provided during installation and automatically installed into `$PREFIX/share/dmenu-extended`, where `$PREFIX` is either `/usr` or `~/.local`, depending on whether a system-wide or per-user installation is performed.

A shell script (`systemd-install.sh`) to install the systemd unit files is provided but not automatically executed upon installation. I feel that it's a better idea to have the distribution manage the installation of systemd unit files. (For example, one can change the PKGBUILD file on AUR to run the script post-installation.)

## Miscellaneous improvements

Really just a single improvement, namely allowing the customization of the "Open:" prompt.