### PR TITLE
Don't recurse over hidden directories

### DIFF
--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -955,8 +955,10 @@ class dmenu(object):
             print('Scanning files and folders, this may take a while...')
 
         for watchdir in watch_folders:
-            for root, dirs , files in walk(watchdir, followlinks=follow_symlinks):
+            for root, dirs, files in walk(watchdir, topdown=True, followlinks=follow_symlinks):
                 dirs[:] = [d for d in dirs if os.path.join(root,d) not in ignore_folders]
+                if self.prefs['scan_hidden_folders'] == False:
+                    dirs[:] = [d for d in dirs if d.startswith('.') == False]
 
                 if self.prefs['scan_hidden_folders'] or root.find('/.')  == -1:
                     for name in files:
@@ -964,8 +966,7 @@ class dmenu(object):
                             if valid_extensions == True or os.path.splitext(name)[1].lower() in valid_extensions:
                                 filenames.append(os.path.join(root,name))
                     for name in dirs:
-                        if self.prefs['include_hidden_folders'] or name.startswith('.') == False:
-                            foldernames.append(os.path.join(root,name) + '/')
+                        foldernames.append(os.path.join(root,name) + '/')
 
         foldernames = list(filter(lambda x: x not in ignore_folders, foldernames))
 


### PR DESCRIPTION
I found a solution that makes dmenu_extended not recurse into hidden directories.

From the python doc : 

> When topdown is True, the caller can modify the dirnames list in-place (perhaps using del or slice assignment), and walk() will only recurse into the subdirectories whose names remain in dirnames; this can be used to prune the search, impose a specific order of visiting, or even to inform walk() about directories the caller creates or renames before it resumes walk() again. Modifying dirnames when topdown is False has no effect on the behavior of the walk, because in bottom-up mode the directories in dirnames are generated before dirpath itself is generated.

See https://docs.python.org/3/library/os.html?highlight=os.walk#os.walk

