### PR TITLE
Fixed XDG reference

### DIFF
--- a/dmenu_extended.py
+++ b/dmenu_extended.py
@@ -359,7 +359,7 @@ class dmenu(object):
         paths = [os.path.join(data_home,'applications')]
 
         # Get other directories
-        data_other = os.environ.get('XDG_DATADIRS','/usr/local/share:/usr/share').split(":")
+        data_other = os.environ.get('XDG_DATA_DIRS','/usr/local/share:/usr/share').split(":")
         paths.extend([os.path.join(direc,'applications') for direc in data_other])
 
         # Filter paths that don't exist


### PR DESCRIPTION
Following the XDG Base Directory Specification, the variable for data directory is $XDG_DATA_DIRS.
https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html

I found this little bug after installing apps with Flatpak which make use of that variable.